### PR TITLE
corected one line in Getting started regarding installation of NPM modules

### DIFF
--- a/modules/heretic/data/gettingStarted.js
+++ b/modules/heretic/data/gettingStarted.js
@@ -107,7 +107,7 @@ export default [{
     },
     {
         type: "paragraph",
-        content: "Then, you will need to install the required NPM modules and start the build process:",
+        content: "Then, you will need to go to heretic directory, install the required NPM modules and start the build process:",
     },
     {
         type: "code",


### PR DESCRIPTION
Correction was added to this paragraf:

    {
        type: "paragraph",
       BEFORE content: "Then, you will need to install the required NPM modules and start the build process:"
       AFTER content: "Then, you will need to go to heretic directory, install the required NPM modules and start the build process:",
    },
    {
        type: "code",
        language: "bash",
        content: `npm run install-modules`,
    },